### PR TITLE
EDX-4632 Update actions to use Node.js 20

### DIFF
--- a/.github/workflows/reusable-golangci-lint.yml
+++ b/.github/workflows/reusable-golangci-lint.yml
@@ -45,9 +45,9 @@ jobs:
       GOPRIVATE: github.com/IOTechSystems
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # Install Golang
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           # Retrieve go version from go.mod
           go-version-file: "${{ inputs.WORKING_DIRECTORY }}/go.mod"   
@@ -92,7 +92,7 @@ jobs:
         run: make gqlgen
       # Run Go linters       
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@c67416616c29c3c48d26b59c45cadb56966d80aa
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: ${{ env.GOLANGCI_LINT_VERSION }}

--- a/.github/workflows/reusable-sonarqube-scan.yml
+++ b/.github/workflows/reusable-sonarqube-scan.yml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # Install Golang
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           # Retrieve go version from go.mod
           go-version-file: go.mod 


### PR DESCRIPTION
Node.js 16 actions are deprecated. Update actions to use Node.js 20. golangci-lint action still does not have a release tag for node 20, so pin to the specific commit that uses node 20.