### PR TITLE
EDX-5297 Upgrade golangci-lint to v1.61.0

### DIFF
--- a/.github/workflows/reusable-golangci-lint.yml
+++ b/.github/workflows/reusable-golangci-lint.yml
@@ -40,7 +40,7 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     env:
-      GOLANGCI_LINT_VERSION: v1.55.2
+      GOLANGCI_LINT_VERSION: v1.61.0
       GOLANGCI_LINT_FLAGS: --print-issued-lines --max-same-issues 50 --build-tags dev
       GOPRIVATE: github.com/IOTechSystems
     steps:


### PR DESCRIPTION
Upgrade golangci-lint to v1.61.0 for go 1.23 support.