### PR TITLE
ci: Run github action checks for dependabot

### DIFF
--- a/.github/workflows/reusable-golangci-lint.yml
+++ b/.github/workflows/reusable-golangci-lint.yml
@@ -36,7 +36,7 @@ permissions:
  
 jobs:
   golangci:
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    if: ${{ github.actor != 'dependabot[bot]' }} || contains(github.head_ref, 'edgexfoundry')
     name: lint
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/reusable-sonarqube-scan.yml
+++ b/.github/workflows/reusable-sonarqube-scan.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   sonarqube-scan:
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    if: ${{ github.actor != 'dependabot[bot]' }} || contains(github.head_ref, 'edgexfoundry')
     runs-on: ubuntu-latest
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it


### PR DESCRIPTION
In v4, we use the community go modules, so the PR validation needs to be run for dependabot