### PR TITLE
Revert "ci: Run github action checks for dependabot"

### DIFF
--- a/.github/workflows/reusable-golangci-lint.yml
+++ b/.github/workflows/reusable-golangci-lint.yml
@@ -36,7 +36,7 @@ permissions:
  
 jobs:
   golangci:
-    if: ${{ github.actor != 'dependabot[bot]' }} || contains(github.head_ref, 'edgexfoundry')
+    if: ${{ github.actor != 'dependabot[bot]' }}
     name: lint
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/reusable-sonarqube-scan.yml
+++ b/.github/workflows/reusable-sonarqube-scan.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   sonarqube-scan:
-    if: ${{ github.actor != 'dependabot[bot]' }} || contains(github.head_ref, 'edgexfoundry')
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it


### PR DESCRIPTION
Reverts IOTechSystems/github-action-workflow#20

The dependanbot doesn't have permission to clone the private repositories, so the github action can't run successfully.
Back to the situation upgrade go modules without github actions, but we still have Jenkins validations.