### PR TITLE
ci: Run sonarqube check for dependabot

### DIFF
--- a/.github/workflows/reusable-sonarqube-scan.yml
+++ b/.github/workflows/reusable-sonarqube-scan.yml
@@ -17,7 +17,6 @@ permissions:
 
 jobs:
   sonarqube-scan:
-    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it


### PR DESCRIPTION
The main reason is to run tests.